### PR TITLE
update to 5.1rc1

### DIFF
--- a/local_develop.cfg
+++ b/local_develop.cfg
@@ -3,7 +3,7 @@
 
 [buildout]
 extends =
-    https://raw.githubusercontent.com/starzel/buildout/5.0.8/linkto/base.cfg
+    https://raw.githubusercontent.com/starzel/buildout/5.1rc1/linkto/base.cfg
 
 # If you want you can have you eggs picked
 #allow-picked-versions = true

--- a/local_production.cfg
+++ b/local_production.cfg
@@ -1,6 +1,6 @@
 [buildout]
 extends =
-    https://raw.githubusercontent.com/starzel/buildout/5.0.8/linkto/base.cfg
+    https://raw.githubusercontent.com/starzel/buildout/5.1rc1/linkto/base.cfg
 
 # If you want you can have you eggs picked
 #allow-picked-versions = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-setuptools==36.0.1
-zc.buildout==2.9.4
+setuptools==36.5.0
+zc.buildout==2.9.5
 appdirs==1.4.3
 packaging==16.8
 pyparsing==2.2.0


### PR DESCRIPTION
I tested it locally and everything seems to work fine when importing the zexp-files even though they were created with 5.0.x